### PR TITLE
Tarball Based Builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+docs/
+bin/
+README.md
+.gitignore
+tmp/
+.git
+coverage/
+vendor/gems/
+.github/
+.devcontainer/
+.ruby-lsp/
+docker-compose.yml

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -1,0 +1,30 @@
+name: tarball
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tarball:
+    name: tarball
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # pin@v1.221.0
+        with:
+          bundler-cache: true
+
+      - name: tarball
+        run: script/tarball

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: tarball
         run: script/tarball
+
+      - name: tarball test
+        run: spec/acceptance/tarball-test

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -1,3 +1,6 @@
+# this workflow is mainly a demo of how you can use the script/tarball command to create a tarball of the repo/project
+# adapt this to your own needs
+
 name: tarball
 
 on:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -12,11 +12,7 @@ permissions:
 jobs:
   tarball:
     name: tarball
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-bin
-coverage
-logs
-tmp
-vendor/gems
+bin/
+coverage/
+logs/
+tmp/
+tarballs/
+vendor/gems/
 .idea
 .byebug_history
 .local/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+ARG RUBY_VERSION=3
+FROM ruby:${RUBY_VERSION}-slim AS base
+
+# create a nonroot user
+RUN useradd -m nonroot
+
+WORKDIR /app
+
+# install system dependencies
+RUN apt-get -qq update && apt-get --no-install-recommends install -y \
+  build-essential
+
+# install core scripts
+COPY --chown=nonroot:nonroot script ./script
+
+# copy core ruby files first
+COPY --chown=nonroot:nonroot .ruby-version Gemfile Gemfile.lock ./
+
+# copy vendored gems
+COPY --chown=nonroot:nonroot vendor ./vendor
+
+# bootstrap the ruby environment
+RUN RUBY_ENV=production script/bootstrap
+
+# copy the rest of the application
+COPY --chown=nonroot:nonroot . .
+
+# switch to the nonroot user
+USER nonroot
+
+# set the environment to production
+ENV RUBY_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN apt-get -qq update && apt-get --no-install-recommends install -y \
   build-essential \
   git
 
+# set the BUNDLE_APP_CONFIG environment variable
+ENV BUNDLE_APP_CONFIG=/app/.bundle
+
+# copy bundler config
+COPY --chown=nonroot:nonroot .bundle ./.bundle
+
 # install core scripts
 COPY --chown=nonroot:nonroot script ./script
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 
 # install system dependencies
 RUN apt-get -qq update && apt-get --no-install-recommends install -y \
-  build-essential
+  build-essential \
+  git
 
 # install core scripts
 COPY --chown=nonroot:nonroot script ./script
@@ -24,6 +25,9 @@ RUN RUBY_ENV=production script/bootstrap
 
 # copy the rest of the application
 COPY --chown=nonroot:nonroot . .
+
+# change ownership of /app directory to nonroot user
+RUN chown -R nonroot:nonroot /app
 
 # switch to the nonroot user
 USER nonroot

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![test](https://github.com/GrantBirki/ruby-template/actions/workflows/test.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/test.yml)
 [![lint](https://github.com/GrantBirki/ruby-template/actions/workflows/lint.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/lint.yml)
 [![build](https://github.com/GrantBirki/ruby-template/actions/workflows/build.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/build.yml)
+[![tarball](https://github.com/GrantBirki/ruby-template/actions/workflows/tarball.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/tarball.yml)
 
 ## Usage 💻
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ script/docker-build
 ```
 
 The result of this command will be a Docker image built with the name `ruby-template:latest`.
+
+### Building Tarballs
+
+To build a tarball of the application for deployment, run the following command:
+
+```bash
+script/tarball
+```
+
+This will build a docker container and run the `script/build-deploy-tarball` script inside the container. The result will be a tarball in the `tarballs/` directory at the root of the repository.
+
+Tarballs are popular for atomic deployments where the deployment is a simple matter of extracting the tarball to the correct location on the target machine and running the new version of the application. Tarball deploys help to shift the complexity of the deployment process from the target machine to the build server (in this case, the CI server - Actions).

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 [![test](https://github.com/GrantBirki/ruby-template/actions/workflows/test.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/test.yml)
 [![lint](https://github.com/GrantBirki/ruby-template/actions/workflows/lint.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/lint.yml)
 [![build](https://github.com/GrantBirki/ruby-template/actions/workflows/build.yml/badge.svg)](https://github.com/GrantBirki/ruby-template/actions/workflows/build.yml)
+
+## Usage 💻
+
+### Docker Builds
+
+Build a Docker image:
+
+```bash
+script/docker-build
+```
+
+The result of this command will be a Docker image built with the name `ruby-template:latest`.

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -62,4 +62,5 @@ tarball_name="${PLATFORM}-${ARCH}-${VERSION}-${BUILD_SHA}.tar.gz"
 tar $TAR_FLAGS "$TARBALL_DIR/$tarball_name" -C "$temp_dir" .
 
 echo -e "${BLUE}Deployment tarball ${GREEN}created${OFF}: $TARBALL_DIR/$tarball_name"
+echo -e "\n${BLUE}Tarball size${OFF}: $(du -h "$TARBALL_DIR/$tarball_name" | cut -f1)\n"
 echo -e "To ${PURPLE}unzip${OFF} the ${BLUE}tarball${OFF}, use (example):\n\ntar -zxvf $(basename "$TARBALL_DIR")/$tarball_name -C /path/to/destination\n"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -1,0 +1,53 @@
+#! /usr/bin/env bash
+
+set -e
+
+source script/env "$@"
+
+RUBY_ENV=production script/bootstrap
+
+# detect OS version and architecture
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    PLATFORM="linux"
+    VERSION=$(grep '^VERSION_CODENAME=' /etc/os-release | cut -d '=' -f2 || echo "unknown")
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    PLATFORM="macos"
+    VERSION=$(sw_vers -productVersion || echo "unknown")
+else
+    PLATFORM="unknown"
+    VERSION="unknown"
+fi
+
+ARCH=$(uname -m || echo "unknown")
+
+# setup a directory to store the built tarballs in
+tarball_dir="$DIR/tarballs"
+mkdir -p "$tarball_dir"
+
+# create a temporary directory for the build
+temp_dir=$(mktemp -d)
+trap "rm -rf $temp_dir" EXIT
+
+# set BUILD_SHA and BUILD_BRANCH if they are not already set
+: "${BUILD_SHA:=$(git rev-parse HEAD)}"
+: "${BUILD_BRANCH:=$(git rev-parse --abbrev-ref HEAD)}"
+
+# copy all files to the temporary directory
+git checkout-index --prefix="$temp_dir/" -a
+echo "$BUILD_SHA" > "$temp_dir/BUILD_SHA"
+echo "$BUILD_BRANCH" > "$temp_dir/BUILD_BRANCH"
+
+# determine tar verbosity
+TAR_VERBOSITY=${TAR_VERBOSITY:-"loud"}
+if [[ "$TAR_VERBOSITY" == "quiet" ]]; then
+    TAR_FLAGS="-zcf"
+else
+    TAR_FLAGS="-zcvf"
+fi
+
+# compress into a tarball
+tarball_name="${PLATFORM}-${ARCH}-${VERSION}-${BUILD_SHA}.tar.gz"
+tar $TAR_FLAGS "$tarball_dir/$tarball_name" -C "$temp_dir" .
+
+echo -e "${BLUE}Deployment tarball ${GREEN}created${OFF}: $tarball_dir/$tarball_name"
+echo -e "To ${PURPLE}unzip${OFF} the ${BLUE}tarball${OFF}, use (example):\n\ntar -zxvf $tarball_dir/$tarball_name -C /path/to/destination\n"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -43,6 +43,10 @@ echo "$BUILD_BRANCH" > "$temp_dir/BUILD_BRANCH"
 # enter the temporary directory, run script/bootstrap, and then go back to the original directory
 cd "$temp_dir"
 RUBY_ENV=production script/bootstrap
+
+# for debugging - view all the files in the temp dir (top level only)
+ls -lah
+
 cd -
 
 # determine tar verbosity

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -6,6 +6,12 @@ source script/env "$@"
 
 RUBY_ENV=production script/bootstrap
 
+# set the app dir as safe if we are running in CI (Actions)
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+  echo "Setting safe.directory to /app (GitHub Actions)"
+  git config --global --add safe.directory /app
+fi
+
 # detect OS version and architecture
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     PLATFORM="linux"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -10,10 +10,6 @@ RUBY_ENV=production script/bootstrap
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
   echo "setting safe.directory to /app (GitHub Actions)"
   git config --global --add safe.directory /app
-
-  # Ensure the tarballs directory has the correct permissions for the docker container...
-  # ... to write to the tarball dir when running in CI (Actions)
-  chmod -R 666 "$TARBALL_DIR"
 fi
 
 # detect OS version and architecture

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -4,8 +4,6 @@ set -e
 
 source script/env "$@"
 
-RUBY_ENV=production script/bootstrap
-
 # set the app dir as safe if we are running in CI (Actions)
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
   echo "setting safe.directory to /app (GitHub Actions)"
@@ -41,6 +39,11 @@ trap "rm -rf $temp_dir" EXIT
 git checkout-index --prefix="$temp_dir/" -a
 echo "$BUILD_SHA" > "$temp_dir/BUILD_SHA"
 echo "$BUILD_BRANCH" > "$temp_dir/BUILD_BRANCH"
+
+# enter the temporary directory, run script/bootstrap, and then go back to the original directory
+cd "$temp_dir"
+RUBY_ENV=production script/bootstrap
+cd -
 
 # determine tar verbosity
 TAR_VERBOSITY=${TAR_VERBOSITY:-"loud"}

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -10,20 +10,6 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
   git config --global --add safe.directory /app
 fi
 
-# detect OS version and architecture
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    PLATFORM="linux"
-    VERSION=$(grep '^VERSION_CODENAME=' /etc/os-release | cut -d '=' -f2 || echo "unknown")
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    PLATFORM="macos"
-    VERSION=$(sw_vers -productVersion || echo "unknown")
-else
-    PLATFORM="unknown"
-    VERSION="unknown"
-fi
-
-ARCH=$(uname -m || echo "unknown")
-
 # setup a directory to store the built tarballs in
 mkdir -p "$TARBALL_DIR"
 

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -21,8 +21,7 @@ fi
 ARCH=$(uname -m || echo "unknown")
 
 # setup a directory to store the built tarballs in
-tarball_dir="$DIR/tarballs"
-mkdir -p "$tarball_dir"
+mkdir -p "$TARBALL_DIR"
 
 # create a temporary directory for the build
 temp_dir=$(mktemp -d)
@@ -47,7 +46,7 @@ fi
 
 # compress into a tarball
 tarball_name="${PLATFORM}-${ARCH}-${VERSION}-${BUILD_SHA}.tar.gz"
-tar $TAR_FLAGS "$tarball_dir/$tarball_name" -C "$temp_dir" .
+tar $TAR_FLAGS "$TARBALL_DIR/$tarball_name" -C "$temp_dir" .
 
-echo -e "${BLUE}Deployment tarball ${GREEN}created${OFF}: $tarball_dir/$tarball_name"
-echo -e "To ${PURPLE}unzip${OFF} the ${BLUE}tarball${OFF}, use (example):\n\ntar -zxvf $tarball_dir/$tarball_name -C /path/to/destination\n"
+echo -e "${BLUE}Deployment tarball ${GREEN}created${OFF}: $TARBALL_DIR/$tarball_name"
+echo -e "To ${PURPLE}unzip${OFF} the ${BLUE}tarball${OFF}, use (example):\n\ntar -zxvf $(basename "$TARBALL_DIR")/$tarball_name -C /path/to/destination\n"

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -8,8 +8,12 @@ RUBY_ENV=production script/bootstrap
 
 # set the app dir as safe if we are running in CI (Actions)
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
-  echo "Setting safe.directory to /app (GitHub Actions)"
+  echo "setting safe.directory to /app (GitHub Actions)"
   git config --global --add safe.directory /app
+
+  # Ensure the tarballs directory has the correct permissions for the docker container...
+  # ... to write to the tarball dir when running in CI (Actions)
+  chmod -R 666 "$TARBALL_DIR"
 fi
 
 # detect OS version and architecture

--- a/script/docker-build
+++ b/script/docker-build
@@ -4,4 +4,4 @@ set -e
 
 source script/env "$@"
 
-docker build --build-arg RUBY_VERSION=$RBENV_VERSION -t $REPO_NAME .
+docker build --build-arg "RUBY_VERSION=$RBENV_VERSION" -t "$REPO_NAME:latest" .

--- a/script/docker-build
+++ b/script/docker-build
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+set -e
+
+source script/env "$@"
+
+docker build --build-arg RUBY_VERSION=$RBENV_VERSION -t $REPO_NAME .

--- a/script/env
+++ b/script/env
@@ -32,6 +32,24 @@ export RBENV_VERSION
 # set the path to include the rbenv shims if they exist
 [ -d "/usr/share/rbenv/shims" ] && export PATH=/usr/share/rbenv/shims:$PATH
 
+# detect OS version and architecture
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    PLATFORM="linux"
+    VERSION=$(grep '^VERSION_CODENAME=' /etc/os-release | cut -d '=' -f2 || echo "unknown")
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    PLATFORM="macos"
+    VERSION=$(sw_vers -productVersion || echo "unknown")
+else
+    PLATFORM="unknown"
+    VERSION="unknown"
+fi
+
+ARCH=$(uname -m || echo "unknown")
+
+export PLATFORM
+export VERSION
+export ARCH
+
 shopt -s nocasematch # enable case-insensitive matching
 if [[ "$RUBY_ENV" == "production" ]]; then
   export BUNDLE_WITHOUT="development"

--- a/script/env
+++ b/script/env
@@ -18,6 +18,10 @@ export RUBY_ENV
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 export DIR
 
+# The name of the repository is the name of the directory (usually)
+REPO_NAME=$(basename "$PWD")
+export REPO_NAME
+
 # set the ruby version to the one specified in the .ruby-version file
 [ -z "$RBENV_VERSION" ] && RBENV_VERSION=$(cat "$DIR/.ruby-version")
 export RBENV_VERSION

--- a/script/env
+++ b/script/env
@@ -22,6 +22,9 @@ export DIR
 REPO_NAME=$(basename "$PWD")
 export REPO_NAME
 
+TARBALL_DIR="$DIR/tarballs"
+export TARBALL_DIR
+
 # set the ruby version to the one specified in the .ruby-version file
 [ -z "$RBENV_VERSION" ] && RBENV_VERSION=$(cat "$DIR/.ruby-version")
 export RBENV_VERSION

--- a/script/tarball
+++ b/script/tarball
@@ -10,10 +10,15 @@ echo -e "📦 ${BLUE}Building tarball${OFF}"
 : "${BUILD_SHA:=$(git rev-parse HEAD)}"
 : "${BUILD_BRANCH:=$(git rev-parse --abbrev-ref HEAD)}"
 
+echo -e "- ${BLUE}BUILD_SHA${OFF}: $BUILD_SHA"
+echo -e "- ${BLUE}BUILD_BRANCH${OFF}: $BUILD_BRANCH\n"
+
 # build and tag the docker image
 script/docker-build
 
 docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" \
-  -v "$TARBALL_DIR:/app/tarballs" \
+  -v "$TARBALL_DIR:/app/tarballs:rw" \
   -v "$DIR/.git:/app/.git:ro" \
   "$REPO_NAME" script/build-deploy-tarball
+
+echo -e "✅ ${GREEN}Done${OFF} - tarball built${OFF}"

--- a/script/tarball
+++ b/script/tarball
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+set -e
+
+source script/env "$@"
+
+echo -e "📦 ${BLUE}Building tarball${OFF}"
+
+# set BUILD_SHA and BUILD_BRANCH if they are not already set
+: "${BUILD_SHA:=$(git rev-parse HEAD)}"
+: "${BUILD_BRANCH:=$(git rev-parse --abbrev-ref HEAD)}"
+
+# build and tag the docker image
+script/docker-build
+
+docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" \
+  -v "$TARBALL_DIR:/app/tarballs" \
+  -v "$DIR/.git:/app/.git:ro" \
+  "$REPO_NAME" script/build-deploy-tarball

--- a/script/tarball
+++ b/script/tarball
@@ -16,7 +16,7 @@ echo -e "- ${BLUE}BUILD_BRANCH${OFF}: $BUILD_BRANCH\n"
 # build and tag the docker image
 script/docker-build
 
-docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" \
+docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" -e "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
   -v "$TARBALL_DIR:/app/tarballs:rw" \
   -v "$DIR/.git:/app/.git:ro" \
   "$REPO_NAME" script/build-deploy-tarball

--- a/script/tarball
+++ b/script/tarball
@@ -13,6 +13,9 @@ echo -e "📦 ${BLUE}Building tarball${OFF}"
 echo -e "- ${BLUE}BUILD_SHA${OFF}: $BUILD_SHA"
 echo -e "- ${BLUE}BUILD_BRANCH${OFF}: $BUILD_BRANCH\n"
 
+# setup a directory to store the built tarballs in
+mkdir -p "$TARBALL_DIR"
+
 # build and tag the docker image
 script/docker-build
 

--- a/script/tarball
+++ b/script/tarball
@@ -29,6 +29,6 @@ fi
 docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" -e "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
   -v "$TARBALL_DIR:/app/tarballs:rw" \
   -v "$DIR/.git:/app/.git:ro" \
-  "$REPO_NAME" script/build-deploy-tarball
+  "$REPO_NAME:latest" script/build-deploy-tarball
 
 echo -e "✅ ${GREEN}Done${OFF} - tarball built${OFF}"

--- a/script/tarball
+++ b/script/tarball
@@ -16,6 +16,13 @@ echo -e "- ${BLUE}BUILD_BRANCH${OFF}: $BUILD_BRANCH\n"
 # build and tag the docker image
 script/docker-build
 
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+  # Ensure the tarballs directory has the correct permissions for the docker container...
+  # ... to write to the tarball dir when running in CI (Actions)
+  echo "setting permissions on $TARBALL_DIR (GitHub Actions)"
+  chmod -R 666 "$TARBALL_DIR"
+fi
+
 docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" -e "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
   -v "$TARBALL_DIR:/app/tarballs:rw" \
   -v "$DIR/.git:/app/.git:ro" \

--- a/script/tarball
+++ b/script/tarball
@@ -23,7 +23,7 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
   # Ensure the tarballs directory has the correct permissions for the docker container...
   # ... to write to the tarball dir when running in CI (Actions)
   echo "setting permissions on $TARBALL_DIR (GitHub Actions)"
-  chmod -R 666 "$TARBALL_DIR"
+  chmod -R 777 "$TARBALL_DIR"
 fi
 
 docker run -e "BUILD_BRANCH=$BUILD_BRANCH" -e "BUILD_SHA=$BUILD_SHA" -e "GITHUB_ACTIONS=$GITHUB_ACTIONS" \

--- a/spec/acceptance/Dockerfile.tarball
+++ b/spec/acceptance/Dockerfile.tarball
@@ -1,0 +1,28 @@
+ARG RUBY_VERSION=3
+ARG TARBALL="undefined"
+FROM ruby:${RUBY_VERSION}-slim AS base
+
+# create a nonroot user
+RUN useradd -m nonroot
+
+WORKDIR /app
+
+RUN mkdir -p temp/
+
+# copy tarfile
+COPY --chown=nonroot:nonroot ${TARBALL} ./temp/${TARBALL}
+
+# extract tarfile
+RUN tar -zxvf ./temp/${TARBALL} -C /app
+
+# remove the temp directory
+RUN rm -rf ./temp
+
+# change ownership of /app directory to nonroot user
+RUN chown -R nonroot:nonroot /app
+
+# switch to the nonroot user
+USER nonroot
+
+# set the environment to production
+ENV RUBY_ENV=production

--- a/spec/acceptance/tarball-test
+++ b/spec/acceptance/tarball-test
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+set -e
+
+source script/env "$@"
+
+# set BUILD_SHA and BUILD_BRANCH if they are not already set
+: "${BUILD_SHA:=$(git rev-parse HEAD)}"
+: "${BUILD_BRANCH:=$(git rev-parse --abbrev-ref HEAD)}"
+
+tarball_name="${PLATFORM}-${ARCH}-${VERSION}-${BUILD_SHA}.tar.gz"
+
+docker build --build-arg "RUBY_VERSION=$RBENV_VERSION" --build-arg "TARBALL=tarballs/$tarball_name" -t "$REPO_NAME-tarball-test:latest" .
+
+# Run the container and capture the output
+result=$(docker run --rm "$REPO_NAME-tarball-test:latest" bash -c "/app/script/server 2 3")
+
+# Check if the result is exactly 5
+if [[ "$result" == "5" ]]; then
+    echo -e "\n✅ Test passed: Output is 5 as expected"
+    exit 0
+else
+    echo -e "\n❌ Test failed: Expected output to be 5, but got: $result"
+    exit 1
+fi


### PR DESCRIPTION
This pull request does the following:

- Scaffolds a basic Docker build system
- Adds `script/tarball` script for building tarballs for atomic deployments
- Adds a companion CI job to build tarballs on a GitHub Actions runner

It doesn't actually show the _deployment_ aspect of using tarballs but rather it shows how they can be built. It is up the actual implementation of the deployment for how/when the tarballs land on a server for deployment.