### PR TITLE
Harden dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,45 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    vendor: true
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: "monday"
-      time: "21:00"
-    groups:
-      prod-ruby-dependencies:
-        dependency-type: "production"
-        patterns:
-          - "*"
-      dev-ruby-dependencies:
-        dependency-type: "development"
-        patterns:
-          - "*"
-  - package-ecosystem: github-actions
-    directory: "/"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    schedule:
-      interval: weekly
-      day: "tuesday"
-      time: "21:00"
+- package-ecosystem: bundler
+  vendor: true
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: '21:00'
+  groups:
+    prod-ruby-dependencies:
+      dependency-type: production
+      patterns:
+      - "*"
+    dev-ruby-dependencies:
+      dependency-type: development
+      patterns:
+      - "*"
+  cooldown:
+    default-days: 45
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  schedule:
+    interval: weekly
+    day: tuesday
+    time: '21:00'
+  cooldown:
+    default-days: 45
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: docker-compose
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # pin@v1.299.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # pin@v1.299.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # pin@v1.299.0
         with:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # pin@v1.299.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # pin@v1.299.0
         with:


### PR DESCRIPTION
This pins mutable GitHub Actions references where needed and adds 45-day Dependabot cooldowns for configured dependency ecosystems.